### PR TITLE
Refactor DefaultPurpose to mimic the behaviour of the rest of purposes

### DIFF
--- a/app/assets/javascripts/qc.js.erb
+++ b/app/assets/javascripts/qc.js.erb
@@ -191,19 +191,14 @@
         step.submitSequencing();
       });
     },
-    _createConversionInterface: function(toDefault) {
-      if (!toDefault) {
-        var conversion = $('.hidden .conversion-interface').clone();
-        conversion.find('.sibling-purpose').text(this.asset.handle.sibling);
-        this.element.find('.conversion-interface-receiver').append(conversion);
-      }
-      this.element.find('.barcode-printing-form').hide();
-    },
-    createConversionInterface: function() {
-      this._createConversionInterface();
+    createConversionInterface: function(toDefault) {
+      var conversion = $('.hidden .conversion-interface').clone();
+      conversion.find('.sibling-purpose').text(this.asset.handle.sibling);
+      this.element.find('.conversion-interface-receiver').append(conversion);
+      this.createConversionInterfaceToDefault();
     },
     createConversionInterfaceToDefault: function() {
-      this._createConversionInterface(true);
+      this.element.find('.barcode-printing-form').hide();
     },
     validates: function() {
       if (this.asset.handle.with==='invalid') {this.addError(this.asset.purpose+' can not be processed by this pipeline.')};

--- a/app/controllers/qc_assets_controller.rb
+++ b/app/controllers/qc_assets_controller.rb
@@ -42,7 +42,7 @@ class QcAssetsController < ApplicationController
   private
 
   def type_controller
-    ((Settings.purposes[params[:purpose]].nil?) ? Settings.default_purpose : Settings.purposes[params[:purpose]]).type.pluralize
+    Settings.purposes.fetch(params[:purpose], Settings.default_purpose).type.pluralize
   end
 
   def find_asset_from_barcode

--- a/config/application.rb
+++ b/config/application.rb
@@ -85,8 +85,8 @@ module Gatekeeper
 
     config.default_purpose_handler = {
       :with    => 'plate_conversion_to_default',
-      :convert_to => 'QA Plate',
-      :as => 'target'
+      :name    => 'QA Plate',
+      :as      => 'target'
     }
 
     # If no study or project is specified, the config will fall back

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -38,7 +38,7 @@
     :qcable_name: Reporter Plate
 :default_purpose:
   :with: plate_conversion_to_default
-  :convert_to: QA Plate
+  :name: QA Plate
   :as: target
   :uuid: 411f8b70-e1fd-11e5-a20c-44fb42fffe72
   :type: plate

--- a/lib/tasks/config.rake
+++ b/lib/tasks/config.rake
@@ -68,9 +68,10 @@ namespace :config do
       configuration[:purposes] = {}.tap do |purpose|
         puts "Preparing purposes ..."
         puts "... plates"
+        raise 'No default purpose configuration specified.' if Gatekeeper::Application.config.default_purpose_handler.nil?
         api.plate_purpose.all.each do |plate_purpose|
           # Loads the default purpose info
-          if Gatekeeper::Application.config.default_purpose_handler[:convert_to].include?(plate_purpose.name)
+          if Gatekeeper::Application.config.default_purpose_handler[:name].include?(plate_purpose.name)
             configuration[:default_purpose] = Gatekeeper::Application.config.default_purpose_handler.merge({
               :uuid => plate_purpose.uuid,
               :type => 'plate'


### PR DESCRIPTION
and stop the needing of specific implementation for using it inside qc_asset.
The specification of a default purpose handler will be mandatory now in the
configuration.
convert_to parameter is not needed anymore.
